### PR TITLE
Add table-layout fixed

### DIFF
--- a/styles/all.sass
+++ b/styles/all.sass
@@ -102,3 +102,6 @@ h3
 
 .shuri-user-menu
     pointer-events: none
+
+.table .the-table
+    table-layout: fixed


### PR DESCRIPTION
**As is:**

![image](https://user-images.githubusercontent.com/69117259/95306185-bed66800-088f-11eb-964e-c33a32e3eaf6.png)

**To be:**

![image](https://user-images.githubusercontent.com/69117259/95306223-cbf35700-088f-11eb-8ffc-c2970e2a61b4.png)

I have choosen this way as `min-width` is not useable inside of table. If you know better way - please tell.